### PR TITLE
Fix teacher dashboard scrolling

### DIFF
--- a/frontend/src/app/(dashboard)/dashboard/teacher/class/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/teacher/class/page.tsx
@@ -134,7 +134,7 @@ export default function TeacherDashboard() {
   }
 
   return (
-    <div className="flex overflow-hidden flex-col pb-2 w-full bg-white">
+    <div className="flex flex-col h-full overflow-y-auto pb-2 w-full bg-white">
 
       {/* 환영 메시지 */}
       <div className="flex flex-col px-5 py-6">

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -8,9 +8,9 @@ export default function DashboardLayout({
 }) {
   return (
     <DashboardProvider>
-      <div className="h-screen bg-gray-50 overflow-hidden">
+      <div className="flex flex-col h-screen bg-gray-50">
         <CommonHeader />
-        <main className="h-full overflow-hidden">
+        <main className="flex-1 overflow-hidden">
           {children}
         </main>
       </div>

--- a/frontend/src/components/dashboard/DashboardPage.tsx
+++ b/frontend/src/components/dashboard/DashboardPage.tsx
@@ -77,7 +77,7 @@ export function DashboardPage({
     return (
       <div
         ref={pageRef}
-        className="w-full h-full overflow-hidden"
+        className="w-full h-full overflow-y-auto overflow-x-hidden"
         style={{
           width: '100%',
           height: '100%',
@@ -93,7 +93,7 @@ export function DashboardPage({
     return (
       <div
         ref={pageRef}
-        className="w-full h-full overflow-hidden"
+        className="w-full h-full overflow-y-auto overflow-x-hidden"
         style={{
           width: '100%',
           height: '100%',
@@ -110,7 +110,7 @@ export function DashboardPage({
   return (
     <div
       ref={pageRef}
-      className="w-full h-full overflow-hidden"
+      className="w-full h-full overflow-y-auto overflow-x-hidden"
       style={{
         width: '100%',
         height: '100%',
@@ -121,4 +121,4 @@ export function DashboardPage({
       </div>
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- adjust dashboard layout to use flex container
- allow `DashboardPage` to scroll vertically
- make teacher class page scrollable

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f646531548325992318cb85e33cbf